### PR TITLE
Added support for RSS and ATOM feeds to Grains Business Theme

### DIFF
--- a/content/blog/atom.xml
+++ b/content/blog/atom.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+	<title><![CDATA[${site.title}]]></title>
+	<link href="${site.url}${page.url}" rel="self"/>
+	<link href="${site.url}/"/>
+	<updated>${page.lastUpdated.format("yyyy-MM-dd'T'HH:mm:ssXXX", )}</updated>
+	<id>${site.url}/</id>
+	<author>
+	  <name><![CDATA[${site.author}]]></name>
+	  <% if (site.rss.email) { %>
+		<email><![CDATA[${site.rss.email}]]></email>
+	  <% } %>
+	</author>
+	<generator uri="http://sysgears.com/grain/">Grain</generator>
+
+<% page.posts.each { post -> %>
+  <entry>
+    <title type="html"><![CDATA[${post.title}]]></title>
+    <link href="${site.url}${post.url}"/>
+    <updated>${post.date.format("yyyy-MM-dd'T'HH:mm:ssXXX", )}</updated>
+    <id><![CDATA[${site.url}${post.url}]]></id>
+    <content type="html"><![CDATA[${post.render().content}]]></content>
+  </entry>
+<% } %>
+</feed>

--- a/content/blog/rss.xml
+++ b/content/blog/rss.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+
+	<channel>
+	  <title><![CDATA[${site.title}]]></title>
+	  <link>${site.url}${page.url}</link>
+	  <atom:link href="${site.url}${page.url}" rel="self" type="application/rss+xml" />
+	  <description>RSS Feed for <![CDATA[${site.title}]]></description>
+	  <pubDate>${page.lastUpdated.format('E, d MMM yyyy HH:mm:ss Z', )}</pubDate>
+	  <generator>Sysgears Grain</generator>
+
+<% page.posts.each { post -> %>
+	  <item>
+		<guid>${site.url}${post.url}</guid>
+		<title><![CDATA[${post.title}]]></title>
+		<pubDate>${post.date.format('E, d MMM yyyy HH:mm:ss Z', )}</pubDate>
+		<link><![CDATA[${site.url}${post.url}]]></link>
+		<description><![CDATA[${post.render().content}]]></description>
+	  </item>
+<% } %>  
+	  
+	</channel>
+
+</rss>

--- a/theme/src/com/sysgears/theme/ResourceMapper.groovy
+++ b/theme/src/com/sysgears/theme/ResourceMapper.groovy
@@ -42,6 +42,14 @@ class ResourceMapper {
                 updatedResources += Paginator.paginate(items, 'posts', perPage, url, page + model)
             }
             switch (page.url) {
+                case '/blog/atom.xml':
+                case '/blog/rss.xml':
+                    int maxRss = 20
+                    def lastUpdated = new Date(posts.max { it.updated.time }.updated.time as Long)
+
+                    // Here we inject 'posts' variable into the model of 'atom.xml' or 'rss.xml'
+                    updatedResources << (page + [posts: posts.take(maxRss), lastUpdated: lastUpdated, site:this.site])
+                    break
                 case '/blog/':
                     applyPagination(posts, 3, page.url)
                     break


### PR DESCRIPTION
As per [sysgears/grain-theme-business] new feature : No RSS generation support for the blog (#1)

Signed-off-by: Brice Copy brice.copy@gmail.com
